### PR TITLE
backport: fix(): add `"Bad number '2e308'."` into `errorsToSkip`

### DIFF
--- a/lib/hint.coffee
+++ b/lib/hint.coffee
@@ -19,6 +19,7 @@ errorsToSkip = [
   "Wrap the /regexp/ literal in parens to disambiguate the slash operator."
   "Creating global 'for' variable. Should be 'for (var"
   "Missing '()' invoking a constructor." # covered by coffeelint rule non_empty_constructor_needs_parens
+  "Bad number '2e308'."
 ]
 
 # If log is true, prints out results after processing each file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coffee-jshint",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Checks CoffeeScript source for errors using JSHint",
   "engines": {
     "node": ">=0.8.x"


### PR DESCRIPTION
127d6f01a168a09549c1784eacbd9b944b1f5464 from upstream.